### PR TITLE
Add new command to report on-screen color (color picker)

### DIFF
--- a/ActionClassesMacro.h
+++ b/ActionClassesMacro.h
@@ -2,6 +2,7 @@
 // This file is written automatically by a “Run Script” build phase
 #define ACTION_CLASSES \
         @"ClickAction", \
+        @"ColorPickerAction", \
         @"DoubleclickAction", \
         @"DragDownAction", \
         @"DragUpAction", \

--- a/Actions/ColorPickerAction.h
+++ b/Actions/ColorPickerAction.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2007-2015, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+
+@interface ColorPickerAction : NSObject <ActionProtocol> {
+
+}
+
++(NSString *)commandShortcut;
+
++(NSString *)commandDescription;
+
+-(void)performActionWithData:(NSString *)data
+                      inMode:(unsigned)mode;
+
+@end

--- a/Actions/ColorPickerAction.m
+++ b/Actions/ColorPickerAction.m
@@ -38,9 +38,9 @@
 }
 
 +(NSString *)commandDescription {
-    return @"  cp:str Will PRINT the color value at the given screen location.\n"
-    "          The color value is printed as four 8-bit values in decimal, representing,\n"
-    "          in order, red, green, blue, and alpha.\n"
+    return @"  cp:str  Will PRINT the color value at the given screen location.\n"
+    "          The color value is printed as four 8-bit values in decimal,\n"
+    "          representing, in order, red, green, blue, and alpha.\n"
     "          Example: “cp:123,456” might print “127 63 0 255”";
 }
 

--- a/Actions/ColorPickerAction.m
+++ b/Actions/ColorPickerAction.m
@@ -40,8 +40,8 @@
 +(NSString *)commandDescription {
     return @"  cp:str  Will PRINT the color value at the given screen location.\n"
     "          The color value is printed as four 8-bit values in decimal,\n"
-    "          representing, in order, red, green, blue, and alpha.\n"
-    "          Example: “cp:123,456” might print “127 63 0 255”";
+    "          representing, in order, red, green, and blue.\n"
+    "          Example: “cp:123,456” might print “127 63 0”";
 }
 
 -(void)performActionWithData:(NSString *)data
@@ -83,7 +83,7 @@
             CGImageRelease(imageRef);
             NSColor *color = [bitmap colorAtX:0 y:0];
 
-            printf("%d %d %d %d\n", (int)(color.redComponent*255), (int)(color.greenComponent*255), (int)(color.blueComponent*255), (int)(color.alphaComponent*255));
+            printf("%d %d %d\n", (int)(color.redComponent*255), (int)(color.greenComponent*255), (int)(color.blueComponent*255));
         }
     }
 

--- a/Actions/ColorPickerAction.m
+++ b/Actions/ColorPickerAction.m
@@ -77,7 +77,7 @@
             CGImageRelease(imageRef);
             color = [bitmap colorAtX:0 y:0];
 
-            printf("%f %f %f %f\n", color.redComponent, color.greenComponent, color.blueComponent, color.alphaComponent);
+            printf("%02x %02x %02x %02x\n", (int)(color.redComponent*255), (int)(color.greenComponent*255), (int)(color.blueComponent*255), (int)(color.alphaComponent*255));
         }
     }
 

--- a/Actions/ColorPickerAction.m
+++ b/Actions/ColorPickerAction.m
@@ -38,15 +38,14 @@
 }
 
 +(NSString *)commandDescription {
-    return @"  cp[:str] Will PRINT the color at the given screen location.\n"
-    "          Example: “cp:123,456” might print “00FFCC88”";
+    return @"  cp:str Will PRINT the color value at the given screen location.\n"
+    "          The color value is printed as four 8-bit values in decimal, representing,\n"
+    "          in order, red, green, blue, and alpha.\n"
+    "          Example: “cp:123,456” might print “127 63 0 255”";
 }
 
 -(void)performActionWithData:(NSString *)data
                       inMode:(unsigned)mode {
-
-    CGPoint p;
-    NSColor *color;
 
     NSString *shortcut = [[self class] commandShortcut];
 
@@ -68,6 +67,7 @@
         if (MODE_TEST == mode) {
             printf("Print color value of given location\n");
         } else {
+            CGPoint p;
             p.x = [MouseBaseAction getCoordinate:[coords objectAtIndex:0] forAxis:XAXIS];
             p.y = [MouseBaseAction getCoordinate:[coords objectAtIndex:1] forAxis:YAXIS];
 
@@ -75,9 +75,9 @@
             CGImageRef imageRef = CGWindowListCreateImage(imageRect, kCGWindowListOptionOnScreenOnly, kCGNullWindowID, kCGWindowImageDefault);
             NSBitmapImageRep *bitmap = [[NSBitmapImageRep alloc] initWithCGImage:imageRef];
             CGImageRelease(imageRef);
-            color = [bitmap colorAtX:0 y:0];
+            NSColor *color = [bitmap colorAtX:0 y:0];
 
-            printf("%02x %02x %02x %02x\n", (int)(color.redComponent*255), (int)(color.greenComponent*255), (int)(color.blueComponent*255), (int)(color.alphaComponent*255));
+            printf("%d %d %d %d\n", (int)(color.redComponent*255), (int)(color.greenComponent*255), (int)(color.blueComponent*255), (int)(color.alphaComponent*255));
         }
     }
 

--- a/Actions/ColorPickerAction.m
+++ b/Actions/ColorPickerAction.m
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2007-2015, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "ColorPickerAction.h"
+#import "MouseBaseAction.h"
+
+@implementation ColorPickerAction
+
+#pragma mark - ActionProtocol
+
++(NSString *)commandShortcut {
+    return @"cp";
+}
+
++(NSString *)commandDescription {
+    return @"  cp[:str] Will PRINT the color at the given screen location.\n"
+    "          Example: “cp:123,456” might print “00FFCC88”";
+}
+
+-(void)performActionWithData:(NSString *)data
+                      inMode:(unsigned)mode {
+
+    CGPoint p;
+    NSColor *color;
+
+    NSString *shortcut = [[self class] commandShortcut];
+
+    if ([data isEqualToString:@""]) {
+        [NSException raise:@"InvalidCommandException"
+                    format:@"Missing argument to command “%@”: Expected two coordinates (separated by a comma). Example: “%@:123,456”",
+                           shortcut, shortcut];
+    } else {
+        NSArray *coords = [data componentsSeparatedByString:@","];
+
+        if ([coords count] != 2 ||
+            [[coords objectAtIndex:1] isEqualToString:@""])
+        {
+            [NSException raise:@"InvalidCommandException"
+                        format:@"Invalid argument “%@” to command “%@”: Expected two coordinates, separated by a comma. Example: “%@:123,456”",
+                               data, shortcut, shortcut];
+        }
+
+        if (MODE_TEST == mode) {
+            printf("Print color value of given location\n");
+        } else {
+            p.x = [MouseBaseAction getCoordinate:[coords objectAtIndex:0] forAxis:XAXIS];
+            p.y = [MouseBaseAction getCoordinate:[coords objectAtIndex:1] forAxis:YAXIS];
+
+            CGRect imageRect = CGRectMake(p.x, p.y, 1, 1);
+            CGImageRef imageRef = CGWindowListCreateImage(imageRect, kCGWindowListOptionOnScreenOnly, kCGNullWindowID, kCGWindowImageDefault);
+            NSBitmapImageRep *bitmap = [[NSBitmapImageRep alloc] initWithCGImage:imageRef];
+            CGImageRelease(imageRef);
+            color = [bitmap colorAtX:0 y:0];
+
+            printf("%f %f %f %f\n", color.redComponent, color.greenComponent, color.blueComponent, color.alphaComponent);
+        }
+    }
+
+}
+
+@end

--- a/Actions/ColorPickerAction.m
+++ b/Actions/ColorPickerAction.m
@@ -54,14 +54,20 @@
                     format:@"Missing argument to command “%@”: Expected two coordinates (separated by a comma). Example: “%@:123,456”",
                            shortcut, shortcut];
     } else {
-        NSArray *coords = [data componentsSeparatedByString:@","];
+        NSArray *coords;
 
-        if ([coords count] != 2 ||
-            [[coords objectAtIndex:1] isEqualToString:@""])
-        {
-            [NSException raise:@"InvalidCommandException"
-                        format:@"Invalid argument “%@” to command “%@”: Expected two coordinates, separated by a comma. Example: “%@:123,456”",
-                               data, shortcut, shortcut];
+        if ([data isEqualToString:@"."]) {
+            coords = [NSArray arrayWithObjects: @"+0", @"+0", nil];
+        } else {
+            coords = [data componentsSeparatedByString:@","];
+
+            if ([coords count] != 2 ||
+                [[coords objectAtIndex:1] isEqualToString:@""])
+            {
+                [NSException raise:@"InvalidCommandException"
+                            format:@"Invalid argument “%@” to command “%@”: Expected two coordinates, separated by a comma. Example: “%@:123,456”",
+                                   data, shortcut, shortcut];
+            }
         }
 
         if (MODE_TEST == mode) {

--- a/Actions/ColorPickerAction.m
+++ b/Actions/ColorPickerAction.m
@@ -51,8 +51,8 @@
 
     if ([data isEqualToString:@""]) {
         [NSException raise:@"InvalidCommandException"
-                    format:@"Missing argument to command “%@”: Expected two coordinates (separated by a comma). Example: “%@:123,456”",
-                           shortcut, shortcut];
+                    format:@"Missing argument to command “%@”: Expected two coordinates (separated by a comma) or “.”. Example: “%@:123,456” or “%@:.”",
+                           shortcut, shortcut, shortcut];
     } else {
         NSArray *coords;
 
@@ -65,8 +65,8 @@
                 [[coords objectAtIndex:1] isEqualToString:@""])
             {
                 [NSException raise:@"InvalidCommandException"
-                            format:@"Invalid argument “%@” to command “%@”: Expected two coordinates, separated by a comma. Example: “%@:123,456”",
-                                   data, shortcut, shortcut];
+                            format:@"Invalid argument “%@” to command “%@”: Expected two coordinates (separated by a comma) or “.”. Example: “%@:123,456” or “%@:.”",
+                                   data, shortcut, shortcut, shortcut];
             }
         }
 

--- a/Actions/ColorPickerAction.m
+++ b/Actions/ColorPickerAction.m
@@ -62,6 +62,7 @@
             coords = [data componentsSeparatedByString:@","];
 
             if ([coords count] != 2 ||
+                [[coords objectAtIndex:0] isEqualToString:@""] ||
                 [[coords objectAtIndex:1] isEqualToString:@""])
             {
                 [NSException raise:@"InvalidCommandException"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CC = cc
 CFLAGS = -include cliclick_Prefix.pch -I Actions -I .
 
 cliclick: Actions/ClickAction.o \
+          Actions/ColorPickerAction.o \
           Actions/DoubleclickAction.o \
           Actions/DragDownAction.o \
           Actions/DragUpAction.o \


### PR DESCRIPTION
In using cliclick to automate things, I sometimes find that I need to determine what's on the screen, and the simplest form of that is reporting the color of a particular pixel.

I've implemented a command, "cp" (for Color Picker), that reports the RGBA values of any pixel on screen, using the same point referencing as the other cliclick commands.

I specifically didn't implement a default location, as the default location would be the mouse pointer, which is likely to just report the color of the pointer itself.  If you really want that point, you can reference it explicitly: `cp:+0,+0`.