### PR TITLE
Update Makefile to include RightClickAction class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ cliclick: Actions/ClickAction.o \
           Actions/MouseBaseAction.o \
           Actions/MoveAction.o \
           Actions/PrintAction.o \
+          Actions/RightClickAction.o \
           Actions/TripleclickAction.o \
           Actions/TypeAction.o \
           Actions/WaitAction.o \


### PR DESCRIPTION
This fixed #47 , which occurs since the RightClickAction class is not linked when building via `make` and thus the class is not found when looking it up via `NSClassFromString(classname)`, resulting in an empty shortcut string being inserted as key into a NSMutableDictionary.