### PR TITLE
Fix build failure on 32-bit macOS

### DIFF
--- a/Actions/MouseBaseAction.m
+++ b/Actions/MouseBaseAction.m
@@ -157,7 +157,7 @@
     uint32_t eventConstant = [self getMoveEventConstant];
     float startX = currentLocation.x;
     float startY = currentLocation.y;
-    float distance = [self distanceBetweenPoint:currentLocation andPoint:NSMakePoint(endX, endY)];
+    float distance = [self distanceBetweenPoint:NSPointFromCGPoint(currentLocation) andPoint:NSMakePoint(endX, endY)];
 
     unsigned steps = ((int)(distance * easing / 100)) + 1;
     float xDiff = (endX - startX);


### PR DESCRIPTION
On 64-bit macOS `NSPoint` is `typedef`'d to `CGPoint`, but on 32-bit macOS they are distinct types, which causes the following build failure:

```
Actions/MouseBaseAction.m:160:49: error: sending 'CGPoint' (aka 'struct CGPoint') to parameter of incompatible type 'NSPoint' (aka 'struct _NSPoint')
    float distance = [self distanceBetweenPoint:currentLocation andPoint:NSMakePoint(endX, endY)];
                                                ^~~~~~~~~~~~~~~
```
