### PR TITLE
Use $(CC) in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ cliclick: Actions/ClickAction.o \
           KeycodeInformer.o \
           OutputHandler.o \
           cliclick.o
-	gcc -o cliclick $^ -framework Cocoa -framework Carbon
+	$(CC) -o cliclick $^ -framework Cocoa -framework Carbon
 
 install: macros cliclick
 	cp cliclick /usr/local/bin/


### PR DESCRIPTION
This allows a command like `make CC=clang` to use that compiler for all steps.