### PR TITLE
Add function prototypes to interface

### DIFF
--- a/Actions/MouseBaseAction.h
+++ b/Actions/MouseBaseAction.h
@@ -91,4 +91,8 @@ typedef enum {
 
 - (uint32_t)getMoveEventConstant;
 
+- (float)distanceBetweenPoint:(NSPoint)a andPoint:(NSPoint)b;
+
+- (float)cubicEaseInOut:(float)p;
+
 @end


### PR DESCRIPTION
At the point where `distanceBetweenPoint` or `cubicEaseInOut` are invoked, old compilers complain:

```
error: incompatible types in initialization
```

This is solved by declaring the function prototypes in the interface.