### PR TITLE
Declare for loop variable outside of loop

### DIFF
--- a/Actions/MouseBaseAction.m
+++ b/Actions/MouseBaseAction.m
@@ -164,7 +164,8 @@
     float yDiff = (endY - startY);
     float stepSize = 1.0 / (float)steps;
 
-    for (unsigned i = 0; i < steps; i ++) {
+    unsigned i;
+    for (i = 0; i < steps; i ++) {
         float factor = [self cubicEaseInOut:(stepSize * i)];
         CGEventRef eventRef = CGEventCreateMouseEvent(NULL, eventConstant, CGPointMake(startX + (factor * xDiff), startY + (factor * yDiff)), 0);
         CGEventPost(kCGHIDEventTap, eventRef);


### PR DESCRIPTION
Old compilers that default to C89 mode complain:

```
error: ‘for’ loop initial declaration used outside C99 mode
```

This is the only change needed to regain C89 compatibility.

Alternately, if you are no longer interested in maintaining C89 compatibility, you could specify C99 mode in the Xcode project instead of relying on the compiler's default language mode.