### PR TITLE
drag move (dm) command to enable drawing patterns 

### DIFF
--- a/Actions/DragMoveAction.h
+++ b/Actions/DragMoveAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2018, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface DragMoveAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/DragMoveAction.m
+++ b/Actions/DragMoveAction.m
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2007-2018, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "DragMoveAction.h"
+#include <unistd.h>
+
+@implementation DragMoveAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"dm";
+}
+
++ (NSString *)commandDescription {
+    return @"  dm:x,y  Will continue the DRAG event to the given coordinates.\n"
+    "          Example: “dm:112,134” will drag and continue to the point with x\n"
+    "          coordinate 112 and y coordinate 134.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Drag move to %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+}
+
+- (uint32_t)getMoveEventConstant {
+    return kCGEventLeftMouseDragged;
+}
+
+@end

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ cliclick: Actions/ClickAction.o \
           Actions/DoubleclickAction.o \
           Actions/DragDownAction.o \
           Actions/DragUpAction.o \
+          Actions/DragMoveAction.o \
           Actions/KeyBaseAction.o \
           Actions/KeyDownAction.o \
           Actions/KeyDownUpBaseAction.o \

--- a/Test.py
+++ b/Test.py
@@ -254,6 +254,21 @@ assertOutput(
     ""
 )
 
+# Assertions for drag move / dm command
+assertOutput(
+    "When using “drag move” (“dm”) command without coordinates, should write nothing to stdout and error to stderr",
+    "dm",
+    "",
+    "Missing argument to command “dm”"
+)
+
+assertOutput(
+    "When using “drag move (“dm”) in testing mode, should write action to stdout and nothing to stderr",
+    "-m test dm:1129,64",
+    "Drag move to 1129,64",
+    ""
+)
+
 # Assertions for wait / w command
 assertOutput(
     "When using “wait” (“w”) command without argument, should write nothing to stdout and error to stderr",


### PR DESCRIPTION
drag move (dm) command to enable drawing patterns (move/drag while mouse is clicked)

ex: `cliclick dd:56,305 dm:143,305 dm:232,305 du:143,390`