### PR TITLE
Warn if cliclick doesn't have accessibility privileges

### DIFF
--- a/cliclick.m
+++ b/cliclick.m
@@ -58,6 +58,12 @@ int main (int argc, const char * argv[]) {
     BOOL restoreOption = NO;
     int optchar;
 
+    if (! AXIsProcessTrusted()) {
+        fprintf(stderr, "WARNING: Accessibility privileges not enabled. Many actions may fail.\n");
+        fprintf(stderr, "         Enable the checkbox for the containing app in:\n");
+        fprintf(stderr, "         System Preferences → Security & Privacy → Accessibility\n");
+    }
+
     while ((optchar = getopt(argc, (char * const *)argv, "horVne:f:d:m:w:")) != -1) {
         switch(optchar) {
             case 'h':


### PR DESCRIPTION
It recently took me a while to figure out why `cliclick` wasn't working. I don't know why the accessibility privileges were gone from my terminal, but it would have been nice if `cliclick` had just told me instead of failing silently.

Fixes #154 