### PR TITLE
Add mouse actions for dragging with the right mouse button

### DIFF
--- a/Actions/RightDragDownAction.h
+++ b/Actions/RightDragDownAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface RightDragDownAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/RightDragDownAction.m
+++ b/Actions/RightDragDownAction.m
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "RightDragDownAction.h"
+
+@implementation RightDragDownAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"rdd";
+}
+
++ (NSString *)commandDescription {
+    return @"  rdd:x,y  Will press the right mouse button down to START A DRAG\n"
+    "  at the given coordinates.\n"
+    "          Example: “rdd:12,34” will press the right mouse button down at\n"
+    "          the point with x coordinate 12 and y coordinate 34. Instead of\n"
+    "          x and y values, you may also use “.”, which means: the current\n"
+    "          position.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Right drag press down at %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+    // Right button down, but don't release
+    CGEventRef rightDown = CGEventCreateMouseEvent(NULL, kCGEventRightMouseDown, p, kCGMouseButtonRight);
+    CGEventPost(kCGHIDEventTap, rightDown);
+    CFRelease(rightDown);
+}
+
+@end

--- a/Actions/RightDragMoveAction.h
+++ b/Actions/RightDragMoveAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface RightDragMoveAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/RightDragMoveAction.m
+++ b/Actions/RightDragMoveAction.m
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "RightDragMoveAction.h"
+#include <unistd.h>
+
+@implementation RightDragMoveAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"rdm";
+}
+
++ (NSString *)commandDescription {
+    return @"  rdm:x,y  Will continue the RIGHT DRAG event to the given\n"
+    "          coordinates.\n"
+    "          Example: “rdm:112,134” will drag and continue to the point with x\n"
+    "          coordinate 112 and y coordinate 134.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Right drag move to %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+}
+
+- (uint32_t)getMoveEventConstant {
+    return kCGEventRightMouseDragged;
+}
+
+@end

--- a/Actions/RightDragUpAction.h
+++ b/Actions/RightDragUpAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface RightDragUpAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/RightDragUpAction.m
+++ b/Actions/RightDragUpAction.m
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "RightDragUpAction.h"
+#include <unistd.h>
+
+@implementation RightDragUpAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"rdu";
+}
+
++ (NSString *)commandDescription {
+    return @"  rdu:x,y  Will release to END A RIGHT BUTTON DRAG at the given\n"
+    "          coordinates.\n"
+    "          Example: “rdu:112,134” will release at the point with x\n"
+    "          coordinate 112 and y coordinate 134.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Right drag release at %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+    // Right button up
+    CGEventRef rightUp = CGEventCreateMouseEvent(NULL, kCGEventRightMouseUp, p, kCGMouseButtonRight);
+    CGEventPost(kCGHIDEventTap, rightUp);
+    CFRelease(rightUp);
+}
+
+- (uint32_t)getMoveEventConstant {
+    return kCGEventRightMouseDragged;
+}
+
+@end

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ cliclick: Actions/ClickAction.o \
           Actions/MoveAction.o \
           Actions/PrintAction.o \
           Actions/RightClickAction.o \
+          Actions/RightDragDownAction.o \
+          Actions/RightDragUpAction.o \
+          Actions/RightDragMoveAction.o \
           Actions/TripleclickAction.o \
           Actions/TypeAction.o \
           Actions/WaitAction.o \

--- a/cliclick.xcodeproj/project.pbxproj
+++ b/cliclick.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		5B9FEE9A1DDF5E6F0020F6F6 /* RightClickAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B9FEE991DDF5E6F0020F6F6 /* RightClickAction.m */; };
 		8DD76F9A0486AA7600D96B5E /* cliclick.m in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* cliclick.m */; settings = {ATTRIBUTES = (); }; };
 		8DD76F9C0486AA7600D96B5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* Foundation.framework */; };
+		CF8E1D342C88E94E005F9B02 /* RightDragDownAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CF8E1D332C88E94E005F9B02 /* RightDragDownAction.m */; };
+		CF8E1D372C88E986005F9B02 /* RightDragMoveAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CF8E1D362C88E986005F9B02 /* RightDragMoveAction.m */; };
+		CF8E1D3A2C88E9C3005F9B02 /* RightDragUpAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CF8E1D392C88E9C3005F9B02 /* RightDragUpAction.m */; };
 		F0A674F818EE2D0C0062FD29 /* DragDownAction.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A674F718EE2D0C0062FD29 /* DragDownAction.m */; };
 		F0A674FB18EE3F220062FD29 /* DragUpAction.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A674FA18EE3F220062FD29 /* DragUpAction.m */; };
 /* End PBXBuildFile section */
@@ -98,6 +101,12 @@
 		5B9FEE981DDF5E6F0020F6F6 /* RightClickAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RightClickAction.h; path = Actions/RightClickAction.h; sourceTree = "<group>"; };
 		5B9FEE991DDF5E6F0020F6F6 /* RightClickAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RightClickAction.m; path = Actions/RightClickAction.m; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* cliclick */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cliclick; sourceTree = BUILT_PRODUCTS_DIR; };
+		CF8E1D322C88E90F005F9B02 /* RightDragDownAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RightDragDownAction.h; path = Actions/RightDragDownAction.h; sourceTree = "<group>"; };
+		CF8E1D332C88E94E005F9B02 /* RightDragDownAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RightDragDownAction.m; path = Actions/RightDragDownAction.m; sourceTree = "<group>"; };
+		CF8E1D352C88E96C005F9B02 /* RightDragMoveAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RightDragMoveAction.h; path = Actions/RightDragMoveAction.h; sourceTree = "<group>"; };
+		CF8E1D362C88E986005F9B02 /* RightDragMoveAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RightDragMoveAction.m; path = Actions/RightDragMoveAction.m; sourceTree = "<group>"; };
+		CF8E1D382C88E9A1005F9B02 /* RightDragUpAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RightDragUpAction.h; path = Actions/RightDragUpAction.h; sourceTree = "<group>"; };
+		CF8E1D392C88E9C3005F9B02 /* RightDragUpAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RightDragUpAction.m; path = Actions/RightDragUpAction.m; sourceTree = "<group>"; };
 		F0A674F618EE2D0C0062FD29 /* DragDownAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DragDownAction.h; path = Actions/DragDownAction.h; sourceTree = "<group>"; };
 		F0A674F718EE2D0C0062FD29 /* DragDownAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DragDownAction.m; path = Actions/DragDownAction.m; sourceTree = "<group>"; };
 		F0A674F918EE3F220062FD29 /* DragUpAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DragUpAction.h; path = Actions/DragUpAction.h; sourceTree = "<group>"; };
@@ -199,6 +208,12 @@
 				22E5626416BA589200CD5D86 /* MoveAction.m */,
 				5B9FEE981DDF5E6F0020F6F6 /* RightClickAction.h */,
 				5B9FEE991DDF5E6F0020F6F6 /* RightClickAction.m */,
+				CF8E1D322C88E90F005F9B02 /* RightDragDownAction.h */,
+				CF8E1D332C88E94E005F9B02 /* RightDragDownAction.m */,
+				CF8E1D352C88E96C005F9B02 /* RightDragMoveAction.h */,
+				CF8E1D362C88E986005F9B02 /* RightDragMoveAction.m */,
+				CF8E1D382C88E9A1005F9B02 /* RightDragUpAction.h */,
+				CF8E1D392C88E9C3005F9B02 /* RightDragUpAction.m */,
 				22E5626716BA589200CD5D86 /* TripleclickAction.h */,
 				22E5626816BA589200CD5D86 /* TripleclickAction.m */,
 			);
@@ -358,9 +373,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				8DD76F9A0486AA7600D96B5E /* cliclick.m in Sources */,
+				CF8E1D372C88E986005F9B02 /* RightDragMoveAction.m in Sources */,
 				223F8ECB15BDF8290078A313 /* ActionExecutor.m in Sources */,
 				22E5626B16BA589200CD5D86 /* ClickAction.m in Sources */,
 				22E5626C16BA589200CD5D86 /* DoubleclickAction.m in Sources */,
+				CF8E1D342C88E94E005F9B02 /* RightDragDownAction.m in Sources */,
 				22E5626D16BA589200CD5D86 /* KeyDownAction.m in Sources */,
 				22E5626E16BA589200CD5D86 /* KeyPressAction.m in Sources */,
 				22E5626F16BA589200CD5D86 /* KeyUpAction.m in Sources */,
@@ -379,6 +396,7 @@
 				22C0ECEE16BAFD9800E3A46C /* KeyBaseAction.m in Sources */,
 				F0A674F818EE2D0C0062FD29 /* DragDownAction.m in Sources */,
 				F0A674FB18EE3F220062FD29 /* DragUpAction.m in Sources */,
+				CF8E1D3A2C88E9C3005F9B02 /* RightDragUpAction.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This program implements mouse down, mouse up, and mouse move actions for dragging using the left mouse button, but none for dragging using the right mouse button. Adding these also enables an application to press and hold the right mouse button down for a longer length of time before releasing it, which, among other things, is needed to hold up a shield in Minecraft.