### PR TITLE
Add mouse actions for center button

### DIFF
--- a/Actions/CenterClickAction.h
+++ b/Actions/CenterClickAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface CenterClickAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/CenterClickAction.m
+++ b/Actions/CenterClickAction.m
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "CenterClickAction.h"
+#include <unistd.h>
+
+@implementation CenterClickAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"cc";
+}
+
++ (NSString *)commandDescription {
+    return @"  cc:x,y  Will CENTER-CLICK at the point with the given\n"
+    "          coordinates.\n"
+    "          Example: “cc:12,34” will center-click at the point with x\n"
+    "          coordinate 12 and y coordinate 34. Instead of x and y values,\n"
+    "          you may also use “.”, which means: the current position. Using\n"
+    "          “.” is equivalent to using relative zero values “c:+0,+0”.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Center-click at %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+    // Center button down
+    CGEventRef centerDown = CGEventCreateMouseEvent(NULL, kCGEventOtherMouseDown, p, kCGMouseButtonCenter);
+    CGEventPost(kCGHIDEventTap, centerDown);
+    CFRelease(centerDown);
+
+    usleep(15000); // Improve reliability
+
+    // Center button up
+    CGEventRef centerUp = CGEventCreateMouseEvent(NULL, kCGEventOtherMouseUp, p, kCGMouseButtonCenter);
+    CGEventPost(kCGHIDEventTap, centerUp);
+    CFRelease(centerUp);
+}
+
+@end

--- a/Actions/CenterDragDownAction.h
+++ b/Actions/CenterDragDownAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface CenterDragDownAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/CenterDragDownAction.m
+++ b/Actions/CenterDragDownAction.m
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "CenterDragDownAction.h"
+
+@implementation CenterDragDownAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"cdd";
+}
+
++ (NSString *)commandDescription {
+    return @"  cdd:x,y  Will press the center mouse button down to START A DRAG\n"
+    "          at the given coordinates.\n"
+    "          Example: “cdd:12,34” will press the center mouse button down at\n"
+    "          the point with x coordinate 12 and y coordinate 34. Instead of\n"
+    "          x and y values, you may also use “.”, which means: the current\n"
+    "          position.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Center drag press down at %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+    // Center button down, but don't release
+    CGEventRef centerDown = CGEventCreateMouseEvent(NULL, kCGEventOtherMouseDown, p, kCGMouseButtonCenter);
+    CGEventPost(kCGHIDEventTap, centerDown);
+    CFRelease(centerDown);
+}
+
+@end

--- a/Actions/CenterDragMoveAction.h
+++ b/Actions/CenterDragMoveAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface CenterDragMoveAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/CenterDragMoveAction.m
+++ b/Actions/CenterDragMoveAction.m
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "CenterDragMoveAction.h"
+#include <unistd.h>
+
+@implementation CenterDragMoveAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"cdm";
+}
+
++ (NSString *)commandDescription {
+    return @"  cdm:x,y  Will continue the CENTER DRAG event to the given\n"
+    "          coordinates.\n"
+    "          Example: “cdm:112,134” will drag and continue to the point with x\n"
+    "          coordinate 112 and y coordinate 134.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Center drag move to %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+}
+
+- (uint32_t)getMoveEventConstant {
+    return kCGEventOtherMouseDragged;
+}
+
+@end

--- a/Actions/CenterDragUpAction.h
+++ b/Actions/CenterDragUpAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface CenterDragUpAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/CenterDragUpAction.m
+++ b/Actions/CenterDragUpAction.m
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "CenterDragUpAction.h"
+#include <unistd.h>
+
+@implementation CenterDragUpAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"cdu";
+}
+
++ (NSString *)commandDescription {
+    return @"  cdu:x,y  Will release to END A CENTER BUTTON DRAG at the given\n"
+    "          coordinates.\n"
+    "          Example: “cdu:112,134” will release at the point with x\n"
+    "          coordinate 112 and y coordinate 134.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Center drag release at %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+    // Center button up
+    CGEventRef centerUp = CGEventCreateMouseEvent(NULL, kCGEventOtherMouseUp, p, kCGMouseButtonCenter);
+    CGEventPost(kCGHIDEventTap, centerUp);
+    CFRelease(centerUp);
+}
+
+- (uint32_t)getMoveEventConstant {
+    return kCGEventOtherMouseDragged;
+}
+
+@end

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ all: macros cliclick
 macros:
 	./generate-action-classes-macro.sh
 
-cliclick: Actions/ClickAction.o \
+cliclick: Actions/CenterClickAction.o \
+          Actions/CenterDragDownAction.o \
+          Actions/CenterDragUpAction.o \
+          Actions/CenterDragMoveAction.o \
+          Actions/ClickAction.o \
           Actions/ColorPickerAction.o \
           Actions/DoubleclickAction.o \
           Actions/DragDownAction.o \

--- a/cliclick.xcodeproj/project.pbxproj
+++ b/cliclick.xcodeproj/project.pbxproj
@@ -32,6 +32,10 @@
 		5B9FEE9A1DDF5E6F0020F6F6 /* RightClickAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B9FEE991DDF5E6F0020F6F6 /* RightClickAction.m */; };
 		8DD76F9A0486AA7600D96B5E /* cliclick.m in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* cliclick.m */; settings = {ATTRIBUTES = (); }; };
 		8DD76F9C0486AA7600D96B5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* Foundation.framework */; };
+		CF9526892C88F2B000BB19EA /* CenterClickAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CF9526882C88F2B000BB19EA /* CenterClickAction.m */; };
+		CF95268C2C88F2E300BB19EA /* CenterDragDownAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CF95268B2C88F2E300BB19EA /* CenterDragDownAction.m */; };
+		CF95268F2C88F30D00BB19EA /* CenterDragMoveAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CF95268E2C88F30D00BB19EA /* CenterDragMoveAction.m */; };
+		CF9526922C88F33700BB19EA /* CenterDragUpAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CF9526912C88F33700BB19EA /* CenterDragUpAction.m */; };
 		F0A674F818EE2D0C0062FD29 /* DragDownAction.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A674F718EE2D0C0062FD29 /* DragDownAction.m */; };
 		F0A674FB18EE3F220062FD29 /* DragUpAction.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A674FA18EE3F220062FD29 /* DragUpAction.m */; };
 /* End PBXBuildFile section */
@@ -98,6 +102,14 @@
 		5B9FEE981DDF5E6F0020F6F6 /* RightClickAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RightClickAction.h; path = Actions/RightClickAction.h; sourceTree = "<group>"; };
 		5B9FEE991DDF5E6F0020F6F6 /* RightClickAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RightClickAction.m; path = Actions/RightClickAction.m; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* cliclick */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cliclick; sourceTree = BUILT_PRODUCTS_DIR; };
+		CF9526872C88F29900BB19EA /* CenterClickAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CenterClickAction.h; path = Actions/CenterClickAction.h; sourceTree = "<group>"; };
+		CF9526882C88F2B000BB19EA /* CenterClickAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CenterClickAction.m; path = Actions/CenterClickAction.m; sourceTree = "<group>"; };
+		CF95268A2C88F2D100BB19EA /* CenterDragDownAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CenterDragDownAction.h; path = Actions/CenterDragDownAction.h; sourceTree = "<group>"; };
+		CF95268B2C88F2E300BB19EA /* CenterDragDownAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CenterDragDownAction.m; path = Actions/CenterDragDownAction.m; sourceTree = "<group>"; };
+		CF95268D2C88F2F800BB19EA /* CenterDragMoveAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CenterDragMoveAction.h; path = Actions/CenterDragMoveAction.h; sourceTree = "<group>"; };
+		CF95268E2C88F30D00BB19EA /* CenterDragMoveAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CenterDragMoveAction.m; path = Actions/CenterDragMoveAction.m; sourceTree = "<group>"; };
+		CF9526902C88F32300BB19EA /* CenterDragUpAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CenterDragUpAction.h; path = Actions/CenterDragUpAction.h; sourceTree = "<group>"; };
+		CF9526912C88F33700BB19EA /* CenterDragUpAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CenterDragUpAction.m; path = Actions/CenterDragUpAction.m; sourceTree = "<group>"; };
 		F0A674F618EE2D0C0062FD29 /* DragDownAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DragDownAction.h; path = Actions/DragDownAction.h; sourceTree = "<group>"; };
 		F0A674F718EE2D0C0062FD29 /* DragDownAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DragDownAction.m; path = Actions/DragDownAction.m; sourceTree = "<group>"; };
 		F0A674F918EE3F220062FD29 /* DragUpAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DragUpAction.h; path = Actions/DragUpAction.h; sourceTree = "<group>"; };
@@ -185,6 +197,14 @@
 			children = (
 				22E5626116BA589200CD5D86 /* MouseBaseAction.h */,
 				22E5626216BA589200CD5D86 /* MouseBaseAction.m */,
+				CF9526872C88F29900BB19EA /* CenterClickAction.h */,
+				CF9526882C88F2B000BB19EA /* CenterClickAction.m */,
+				CF95268A2C88F2D100BB19EA /* CenterDragDownAction.h */,
+				CF95268B2C88F2E300BB19EA /* CenterDragDownAction.m */,
+				CF95268D2C88F2F800BB19EA /* CenterDragMoveAction.h */,
+				CF95268E2C88F30D00BB19EA /* CenterDragMoveAction.m */,
+				CF9526902C88F32300BB19EA /* CenterDragUpAction.h */,
+				CF9526912C88F33700BB19EA /* CenterDragUpAction.m */,
 				22E5625616BA589200CD5D86 /* ClickAction.h */,
 				22E5625716BA589200CD5D86 /* ClickAction.m */,
 				F0A674F618EE2D0C0062FD29 /* DragDownAction.h */,
@@ -357,18 +377,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CF9526892C88F2B000BB19EA /* CenterClickAction.m in Sources */,
 				8DD76F9A0486AA7600D96B5E /* cliclick.m in Sources */,
 				223F8ECB15BDF8290078A313 /* ActionExecutor.m in Sources */,
 				22E5626B16BA589200CD5D86 /* ClickAction.m in Sources */,
 				22E5626C16BA589200CD5D86 /* DoubleclickAction.m in Sources */,
 				22E5626D16BA589200CD5D86 /* KeyDownAction.m in Sources */,
+				CF95268C2C88F2E300BB19EA /* CenterDragDownAction.m in Sources */,
 				22E5626E16BA589200CD5D86 /* KeyPressAction.m in Sources */,
+				CF95268F2C88F30D00BB19EA /* CenterDragMoveAction.m in Sources */,
 				22E5626F16BA589200CD5D86 /* KeyUpAction.m in Sources */,
 				22C68A501825A8960083A722 /* KeyDownUpBaseAction.m in Sources */,
 				22E5627016BA589200CD5D86 /* MouseBaseAction.m in Sources */,
 				22760C932052632600467D47 /* OutputHandler.m in Sources */,
 				2250A92A1966D39000150E07 /* KeycodeInformer.m in Sources */,
 				22E5627116BA589200CD5D86 /* MoveAction.m in Sources */,
+				CF9526922C88F33700BB19EA /* CenterDragUpAction.m in Sources */,
 				22129EB425EA93B500904544 /* DragMoveAction.m in Sources */,
 				22E5627216BA589200CD5D86 /* PrintAction.m in Sources */,
 				22E5627316BA589200CD5D86 /* TripleclickAction.m in Sources */,


### PR DESCRIPTION
This adds commands to click, press down, release, and drag the center mouse button. This button is used to perform some actions in Minecraft, including "pick block" in creative mode.