### PR TITLE
Add mouse actions for scrolling

### DIFF
--- a/Actions/ScrollDownAction.h
+++ b/Actions/ScrollDownAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface ScrollDownAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/ScrollDownAction.m
+++ b/Actions/ScrollDownAction.m
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "ScrollDownAction.h"
+#include <unistd.h>
+
+@implementation ScrollDownAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"sd";
+}
+
++ (NSString *)commandDescription {
+    return @"  sd:x,y   Will SCROLL DOWN 1 line at the point with the given\n"
+    "          coordinates. One line is usually about 10 pixels.\n"
+    "          Example: “sd:12,34” will scroll down at the point with x\n"
+    "          coordinate 12 and y coordinate 34. Instead of x and y values,\n"
+    "          you may also use “.”, which means: the current position. Using\n"
+    "          “.” is equivalent to using relative zero values “c:+0,+0”.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Scroll down 1 line at %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+    // Scroll down 1 line
+    CGEventRef scrollDown = CGEventCreateScrollWheelEvent(NULL, kCGScrollEventUnitLine, 1, -1);
+    CGEventPost(kCGHIDEventTap, scrollDown);
+    CFRelease(scrollDown);
+}
+
+@end

--- a/Actions/ScrollDownPixelAction.h
+++ b/Actions/ScrollDownPixelAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface ScrollDownPixelAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/ScrollDownPixelAction.m
+++ b/Actions/ScrollDownPixelAction.m
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "ScrollDownPixelAction.h"
+#include <unistd.h>
+
+@implementation ScrollDownPixelAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"sdp";
+}
+
++ (NSString *)commandDescription {
+    return @"  sdp:x,y   Will SCROLL DOWN 1 pixel at the point with the given\n"
+   "          coordinates.\n"
+    "          Example: “sdp:12,34” will scroll down at the point with x\n"
+    "          coordinate 12 and y coordinate 34. Instead of x and y values,\n"
+    "          you may also use “.”, which means: the current position. Using\n"
+    "          “.” is equivalent to using relative zero values “c:+0,+0”.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Scroll down 1 pixel at %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+    // Scroll down 1 pixel
+    CGEventRef scrollDown = CGEventCreateScrollWheelEvent(NULL, kCGScrollEventUnitPixel, 1, -1);
+    CGEventPost(kCGHIDEventTap, scrollDown);
+    CFRelease(scrollDown);
+}
+
+@end

--- a/Actions/ScrollUpAction.h
+++ b/Actions/ScrollUpAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface ScrollUpAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/ScrollUpAction.m
+++ b/Actions/ScrollUpAction.m
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "ScrollUpAction.h"
+#include <unistd.h>
+
+@implementation ScrollUpAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"su";
+}
+
++ (NSString *)commandDescription {
+    return @"  su:x,y   Will SCROLL UP 1 line at the point with the given\n"
+    "          coordinates. One line is usually about 10 pixels.\n"
+    "          Example: “su:12,34” will scroll up at the point with x\n"
+    "          coordinate 12 and y coordinate 34. Instead of x and y values,\n"
+    "          you may also use “.”, which means: the current position. Using\n"
+    "          “.” is equivalent to using relative zero values “c:+0,+0”.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Scroll up 1 line at %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+    // Scroll up 1 line
+    CGEventRef scrollUp = CGEventCreateScrollWheelEvent(NULL, kCGScrollEventUnitLine, 1, 1);
+    CGEventPost(kCGHIDEventTap, scrollUp);
+    CFRelease(scrollUp);
+}
+
+@end

--- a/Actions/ScrollUpPixelAction.h
+++ b/Actions/ScrollUpPixelAction.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "ActionProtocol.h"
+#import "MouseBaseAction.h"
+
+@interface ScrollUpPixelAction : MouseBaseAction <ActionProtocol> {
+
+}
+
++ (NSString *)commandShortcut;
+
++ (NSString *)commandDescription;
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription;
+
+- (void)performActionAtPoint:(CGPoint) p;
+
+@end

--- a/Actions/ScrollUpPixelAction.m
+++ b/Actions/ScrollUpPixelAction.m
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2007-2021, Carsten Blüm <carsten@bluem.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of Carsten Blüm nor the names of his contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "ScrollUpPixelAction.h"
+#include <unistd.h>
+
+@implementation ScrollUpPixelAction
+
+#pragma mark - ActionProtocol
+
++ (NSString *)commandShortcut {
+    return @"sup";
+}
+
++ (NSString *)commandDescription {
+    return @"  sup:x,y   Will SCROLL UP 1 pixel at the point with the given\n"
+    "          coordinates.\n"
+    "          Example: “sup:12,34” will scroll up at the point with x\n"
+    "          coordinate 12 and y coordinate 34. Instead of x and y values,\n"
+    "          you may also use “.”, which means: the current position. Using\n"
+    "          “.” is equivalent to using relative zero values “c:+0,+0”.";
+}
+
+#pragma mark - MouseBaseAction
+
+- (NSString *)actionDescriptionString:(NSString *)locationDescription {
+    return [NSString stringWithFormat:@"Scroll up 1 pixel at %@", locationDescription];
+}
+
+- (void)performActionAtPoint:(CGPoint) p {
+    // Scroll up 1 pixel
+    CGEventRef scrollUp = CGEventCreateScrollWheelEvent(NULL, kCGScrollEventUnitPixel, 1, 1);
+    CGEventPost(kCGHIDEventTap, scrollUp);
+    CFRelease(scrollUp);
+}
+
+@end

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ cliclick: Actions/ClickAction.o \
           Actions/MoveAction.o \
           Actions/PrintAction.o \
           Actions/RightClickAction.o \
+          Actions/ScrollDownAction.o \
+          Actions/ScrollDownPixelAction.o \
+          Actions/ScrollUpAction.o \
+          Actions/ScrollUpPixelAction.o \
           Actions/TripleclickAction.o \
           Actions/TypeAction.o \
           Actions/WaitAction.o \

--- a/cliclick.xcodeproj/project.pbxproj
+++ b/cliclick.xcodeproj/project.pbxproj
@@ -32,6 +32,10 @@
 		5B9FEE9A1DDF5E6F0020F6F6 /* RightClickAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B9FEE991DDF5E6F0020F6F6 /* RightClickAction.m */; };
 		8DD76F9A0486AA7600D96B5E /* cliclick.m in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* cliclick.m */; settings = {ATTRIBUTES = (); }; };
 		8DD76F9C0486AA7600D96B5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* Foundation.framework */; };
+		CFE12B432C88FCC2004B36C5 /* ScrollDownAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CFE12B422C88FCC2004B36C5 /* ScrollDownAction.m */; };
+		CFE12B462C88FCF9004B36C5 /* ScrollDownPixelAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CFE12B452C88FCF9004B36C5 /* ScrollDownPixelAction.m */; };
+		CFE12B492C88FD1B004B36C5 /* ScrollUpAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CFE12B482C88FD1B004B36C5 /* ScrollUpAction.m */; };
+		CFE12B4C2C88FD39004B36C5 /* ScrollUpPixelAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CFE12B4B2C88FD39004B36C5 /* ScrollUpPixelAction.m */; };
 		F0A674F818EE2D0C0062FD29 /* DragDownAction.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A674F718EE2D0C0062FD29 /* DragDownAction.m */; };
 		F0A674FB18EE3F220062FD29 /* DragUpAction.m in Sources */ = {isa = PBXBuildFile; fileRef = F0A674FA18EE3F220062FD29 /* DragUpAction.m */; };
 /* End PBXBuildFile section */
@@ -98,6 +102,14 @@
 		5B9FEE981DDF5E6F0020F6F6 /* RightClickAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RightClickAction.h; path = Actions/RightClickAction.h; sourceTree = "<group>"; };
 		5B9FEE991DDF5E6F0020F6F6 /* RightClickAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RightClickAction.m; path = Actions/RightClickAction.m; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* cliclick */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cliclick; sourceTree = BUILT_PRODUCTS_DIR; };
+		CFE12B412C88FCAF004B36C5 /* ScrollDownAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ScrollDownAction.h; path = Actions/ScrollDownAction.h; sourceTree = "<group>"; };
+		CFE12B422C88FCC2004B36C5 /* ScrollDownAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ScrollDownAction.m; path = Actions/ScrollDownAction.m; sourceTree = "<group>"; };
+		CFE12B442C88FCD4004B36C5 /* ScrollDownPixelAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ScrollDownPixelAction.h; path = Actions/ScrollDownPixelAction.h; sourceTree = "<group>"; };
+		CFE12B452C88FCF9004B36C5 /* ScrollDownPixelAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ScrollDownPixelAction.m; path = Actions/ScrollDownPixelAction.m; sourceTree = "<group>"; };
+		CFE12B472C88FD08004B36C5 /* ScrollUpAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ScrollUpAction.h; path = Actions/ScrollUpAction.h; sourceTree = "<group>"; };
+		CFE12B482C88FD1B004B36C5 /* ScrollUpAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ScrollUpAction.m; path = Actions/ScrollUpAction.m; sourceTree = "<group>"; };
+		CFE12B4A2C88FD2B004B36C5 /* ScrollUpPixelAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ScrollUpPixelAction.h; path = Actions/ScrollUpPixelAction.h; sourceTree = "<group>"; };
+		CFE12B4B2C88FD39004B36C5 /* ScrollUpPixelAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ScrollUpPixelAction.m; path = Actions/ScrollUpPixelAction.m; sourceTree = "<group>"; };
 		F0A674F618EE2D0C0062FD29 /* DragDownAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DragDownAction.h; path = Actions/DragDownAction.h; sourceTree = "<group>"; };
 		F0A674F718EE2D0C0062FD29 /* DragDownAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DragDownAction.m; path = Actions/DragDownAction.m; sourceTree = "<group>"; };
 		F0A674F918EE3F220062FD29 /* DragUpAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DragUpAction.h; path = Actions/DragUpAction.h; sourceTree = "<group>"; };
@@ -199,6 +211,14 @@
 				22E5626416BA589200CD5D86 /* MoveAction.m */,
 				5B9FEE981DDF5E6F0020F6F6 /* RightClickAction.h */,
 				5B9FEE991DDF5E6F0020F6F6 /* RightClickAction.m */,
+				CFE12B412C88FCAF004B36C5 /* ScrollDownAction.h */,
+				CFE12B422C88FCC2004B36C5 /* ScrollDownAction.m */,
+				CFE12B442C88FCD4004B36C5 /* ScrollDownPixelAction.h */,
+				CFE12B452C88FCF9004B36C5 /* ScrollDownPixelAction.m */,
+				CFE12B472C88FD08004B36C5 /* ScrollUpAction.h */,
+				CFE12B482C88FD1B004B36C5 /* ScrollUpAction.m */,
+				CFE12B4A2C88FD2B004B36C5 /* ScrollUpPixelAction.h */,
+				CFE12B4B2C88FD39004B36C5 /* ScrollUpPixelAction.m */,
 				22E5626716BA589200CD5D86 /* TripleclickAction.h */,
 				22E5626816BA589200CD5D86 /* TripleclickAction.m */,
 			);
@@ -365,6 +385,7 @@
 				22E5626E16BA589200CD5D86 /* KeyPressAction.m in Sources */,
 				22E5626F16BA589200CD5D86 /* KeyUpAction.m in Sources */,
 				22C68A501825A8960083A722 /* KeyDownUpBaseAction.m in Sources */,
+				CFE12B4C2C88FD39004B36C5 /* ScrollUpPixelAction.m in Sources */,
 				22E5627016BA589200CD5D86 /* MouseBaseAction.m in Sources */,
 				22760C932052632600467D47 /* OutputHandler.m in Sources */,
 				2250A92A1966D39000150E07 /* KeycodeInformer.m in Sources */,
@@ -374,10 +395,13 @@
 				22E5627316BA589200CD5D86 /* TripleclickAction.m in Sources */,
 				22998C7D197A85A300A4C691 /* TypeAction.m in Sources */,
 				22E5627416BA589200CD5D86 /* WaitAction.m in Sources */,
+				CFE12B462C88FCF9004B36C5 /* ScrollDownPixelAction.m in Sources */,
 				5B9FEE9A1DDF5E6F0020F6F6 /* RightClickAction.m in Sources */,
 				226347791B998B80003C5D71 /* ColorPickerAction.m in Sources */,
 				22C0ECEE16BAFD9800E3A46C /* KeyBaseAction.m in Sources */,
+				CFE12B492C88FD1B004B36C5 /* ScrollUpAction.m in Sources */,
 				F0A674F818EE2D0C0062FD29 /* DragDownAction.m in Sources */,
+				CFE12B432C88FCC2004B36C5 /* ScrollDownAction.m in Sources */,
 				F0A674FB18EE3F220062FD29 /* DragUpAction.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This adds actions for scrolling up and down by 1 line or 1 pixel. This is a very common mouse action, and among other things, this can be used to cycle through the hotbar in Minecraft, or to make things visible on screen that were hidden before.